### PR TITLE
Add what to bring section

### DIFF
--- a/description.html
+++ b/description.html
@@ -289,6 +289,11 @@
         <li>
           Since we will be creating pull requests on GitHub, <strong>please bring your laptop.</strong>
         </li>
+        <li>
+          We have some monitors available for <em>pair-programming</em> and <em>knowledge sharing</em>.
+          It supports USB-C and HDMI, but cables are not available.
+          If you wish to use it, please bring your own cable and adapters.
+        </li>
       </ul>
 
       <h2>

--- a/description.html
+++ b/description.html
@@ -39,6 +39,9 @@
       .custom-description-container a {
         color: #fff922;
       }
+      .custom-description-container strong {
+        color: #fff;
+      }
       
       .custom-schedule {
         display: block;
@@ -273,6 +276,18 @@
           <div class="custom-schedule__track -both -agenda">
             <p>After-party</p>
           </div>
+        </li>
+      </ul>
+
+      <h2>
+        WHAT TO BRING
+      </h2>
+      <ul>
+        <li>
+          If you don’t have one already, please <a href="https://github.com" target="_blank">sign up for a GitHub account</a>.
+        </li>
+        <li>
+          Since we will be creating pull requests on GitHub, <strong>please bring your laptop.</strong>
         </li>
       </ul>
 


### PR DESCRIPTION
Maybe participants don’t know that they need to bring a laptop, as is the case with some prior events.

## Preview

https://raw.githack.com/dtinth/hacktoberfest-open-hack-day-bkk-2019/what-to-bring/index.html
